### PR TITLE
Add git info to pages + improve translation

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -38,3 +38,19 @@ params:
   disableMermaid: false
   customMermaidURL: 'https://unpkg.com/mermaid@8.8.0/dist/mermaid.min.js'
   titleSeparator: '::'
+
+frontmatter:
+  date:
+    - date
+    - publishDate
+    - lastmod
+  lastmod:
+    - lastmod
+    - ':git'
+    - date
+    - publishDate
+  publishDate:
+    - publishDate
+    - date
+  expiryDate:
+    - expiryDate

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -1,0 +1,30 @@
+Search-placeholder:
+  other: Search...
+Clear-History:
+  other: Clear History
+Attachments-label:
+  other: Attachments
+title-404:
+  other: Error
+message-404:
+  other: Woops. Looks like this page doesn't exist ¯\_(ツ)_/¯.
+Go-to-homepage:
+  other: Go to homepage
+Shortcuts-Title:
+  other: More
+Expand-title:
+  other: Expand me...
+BinaryPrefix-kilobyte:
+  other: kb
+
+# GIT info
+Edit-this-page:
+  other: Improve this page
+last_updated:
+  other: was last updated
+by:
+  other: by
+with:
+  other: with
+'on':
+  other: 'on'

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -1,0 +1,30 @@
+Search-placeholder:
+  other: Rechercher...
+Clear-History:
+  other: Supprimer l'historique
+Attachments-label:
+  other: Pièces jointes
+title-404:
+  other: Erreur
+message-404:
+  other: Oups. On dirait que cette page n'existe pas ¯\_(ツ)_/¯
+Go-to-homepage:
+  other: Vers la page d'accueil
+Shortcuts-Title:
+  other: Aller plus loin
+Expand-title:
+  other: Déroulez-moi...
+BinaryPrefix-kilobyte:
+  other: ko
+
+# GIT info
+Edit-this-page:
+  other: Améliorer cette page
+last_updated:
+  other: a été mise à jour
+by:
+  other: par
+with:
+  other: avec le
+'on':
+  other: le

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,0 +1,33 @@
+{{ partial "header.html" . }}
+
+{{ if eq .Kind "section" }}
+	{{ .Content }}
+{{end}}
+
+{{ if or (eq .Kind "taxonomy") (eq .Kind "term") }}
+<ul>
+	{{ range .Pages }}
+		<li><a href="{{.RelPermalink}}">{{.Title}}</a></li>
+	{{ end }}
+</ul>
+{{end}}
+
+
+<footer style="text-align: center;">
+
+  <a href="{{ .Permalink }}" class=""> “{{ .Title }}” </a> {{ T "last_updated" }}
+  {{ T "on" }} {{ .Lastmod.Format "2006-01-02" }}
+  {{ with .GitInfo }} {{ T "by" }}
+  <a class="" href="{{$.Site.Params.github_repo}}/commit/{{ .Hash }}">
+    {{ .AuthorName }}
+  </a>
+  {{ T "with" }} <a class="" href="{{$.Site.Params.github_repo}}/commit/{{ .Hash }}">
+    commit {{ .AbbreviatedHash }}.
+  </a>
+  {{end }}
+
+</footer>
+
+{{ partial "footer.html" . }}
+
+

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,0 +1,23 @@
+{{ partial "header.html" . }}
+
+{{ .Content }}
+
+<footer style="text-align: center;">
+
+    <a href="{{ .Permalink }}" class=""> “{{ .Title }}” </a> was last updated
+    {{ with .GitInfo }} by
+    <a class="" href="{{$.Site.Params.github_repo}}/commit/{{ .Hash }}">
+      {{ .AuthorName }}
+    </a>
+    with <a class="" href="{{$.Site.Params.github_repo}}/commit/{{ .Hash }}">
+      commit {{ .AbbreviatedHash }}
+    </a>
+    {{end }}
+    on {{ .Lastmod.Format "2006-01-02" }}.
+
+</footer>
+
+{{ partial "footer.html" . }}
+
+
+


### PR DESCRIPTION
will need to design it better with proper css, but at least we got the mechanic working.

Devrait être positionné pour que ce soit distinct de la page de contenu, éventuellement.. 

eg:
![image](https://user-images.githubusercontent.com/30598330/110354195-e4fe6080-8005-11eb-89e4-64656942bcab.png)
![image](https://user-images.githubusercontent.com/30598330/110354349-0d865a80-8006-11eb-83a0-84f73b98474e.png)

Closing #4 in favor of this one. 
