### PR TITLE
fix #10 Enhance readability of footnote references

### DIFF
--- a/static/css/theme-osum.css
+++ b/static/css/theme-osum.css
@@ -196,6 +196,21 @@ tr:last-child td:last-child {
   border-bottom-right-radius: 4px;
 }
 
+
+sub, sup {
+  font-weight: bold;
+  vertical-align: top;
+}
+
+sup {
+  top: unset;
+}
+
+h1 sub,
+h1 sup {
+  font-size: 0.6em;
+}
+
 #chapter p {
   text-align: left;
 }


### PR DESCRIPTION
To test this PR, simply create a page in `/content` and add the following snippet:

```
---
title: "Footnotes"
---

# Hello world [^1]

##  Hello world [^1]

### Hello world [^1]

#### Hello world [^1]

##### Hello world [^1]

###### Hello world [^1]

Lorem ipsum dolor sit amet [^1]

[^1]: This is a footnote. Isn't it beautiful?
```

It should look like this:

![image](https://user-images.githubusercontent.com/7339076/111080929-3d869f80-84d7-11eb-84e6-c91df78f8959.png)
