### PR TITLE
fix #12 Reimplement notice shortcode

### DIFF
--- a/layouts/shortcodes/notice.html
+++ b/layouts/shortcodes/notice.html
@@ -1,0 +1,17 @@
+{{ $_hugo_config := `{ "version": 1 }` }}
+
+<!--
+<div class="notices {{ .Get 0 }}" {{ if len .Params | eq 2 }} id="{{ .Get 1 }}" {{ end }}>
+  {{ .Inner }}
+</div>
+-->
+
+<div class="notice-wrapper" {{ if len .Params | eq 2 }} id="{{ .Get 1 }}" {{ end }}>
+  <p class="notice-title notice-{{ .Get 0 }}">
+    <span class="notice-icon fa fa-exclamation-circle" aria-hidden="true"></span>
+    {{ .Get 0 }}
+  </p>
+  <div class="notice-content">
+    {{ .Inner }}
+  </div>
+</div>

--- a/static/css/theme-osum.css
+++ b/static/css/theme-osum.css
@@ -377,22 +377,35 @@ a:hover {
   color: var(--autocomplete-selected-text-color);
 }
 
-div.notices.info p,
-div.notices.note p,
-div.notices.tip p {
+.notice-wrapper {
 	background: var(--notice-bg-color);
   border-radius: 4px;
-	border-top: 30px solid var(--notice-info-title-bg-color);
 	box-shadow: 0px 2px 3px 1px rgba(0, 0, 0, 0.1);
   color: var(--notice-text-color);
 }
 
-div.notices.warning p {
-	background: var(--notice-bg-color);
-  border-radius: 4px;
-	border-top: 30px solid var(--notice-warning-title-bg-color);
-	box-shadow: 0px 2px 3px 1px rgba(0, 0, 0, 0.1);
-  color: var(--notice-text-color);
+.notice-title {
+  border-radius: 4px 4px 0 0;
+  color: var(--grey-10);
+  font-weight: bold;
+  height: 32px;
+  line-height: 32px;
+  padding: 0 8px;
+  text-transform: capitalize;
+}
+
+.notice-content {
+  padding: 0 16px 4px 16px;
+}
+
+.notice-info,
+.notice-note,
+.notice-tip {
+  background-color: var(--notice-info-title-bg-color);
+}
+
+.notice-warning {
+	background: var(--notice-warning-title-bg-color);
 }
 
 .progress {


### PR DESCRIPTION
This solve an issue where every new paragraph was adding an empty titlebar.

Snippet to try in local:

```
{{% notice info %}} Unless you have already registered with another matrix
server and know how to join our server through the federation, the first time
you use our service, you will have to register by clicking on
"[Create Account](https://chat.openscience.ca/#/register)" on the homepage
[https://chat.openscience.ca](https://chat.openscience.ca).

If you require help during the registration process, you can refer to the [First
steps]({{% ref "matrix/first-steps" %}}) section.

Analogous to e-mail addresses, this results in matrix addresses with the
following structure: `@USERNAME:openscience.ca`

{{% /notice %}}
```

Result:

![image](https://user-images.githubusercontent.com/7339076/111082058-a886a500-84dc-11eb-8fc8-df7e9e015c67.png)

